### PR TITLE
Return an empty string if there's no string

### DIFF
--- a/src/Smartsupp/ChatGenerator.php
+++ b/src/Smartsupp/ChatGenerator.php
@@ -377,6 +377,10 @@ class ChatGenerator
      */
     public function javascriptEscape($str)
     {
+        if (!$str) {
+            return '';
+        }
+        
         $new_str = '';
 
         for ($i = 0; $i < mb_strlen($str); $i++) {


### PR DESCRIPTION
If `$str` is empty, an exception will appear.